### PR TITLE
add contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+## How to contribute to Donut
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/plowteam/donut/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/plowteam/donut/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, including your expected outcome vs your observed outcome.
+
+* **Keep issues focused and easy to understand** by limiting discussion to the technical
+problem only. An issue shouldn't take more than a few minutes for a person to read and
+understand.
+
+* Be aware that issues are limited to the scope of the original reported bug. If a new bug is found while
+investigating an existing issue, a new issue should be opened.
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Contributions are always welcome, whether it's modifying source code to add new
 features or bug fixes, documenting new file formats or simply editing some
 grammar.
 
+Please take a moment to read through the [contribution guidelines](./CONTRIBUTING.md).
+
 You can also join the [Discord for development discussion]((https://discord.gg/xpdbWzG))
 if you are unsure of anything.
 


### PR DESCRIPTION
In light of some recent issues like #10, #13, #16, #17, #19 it may be a good idea to expand the contribution guidelines a bit. Basically just a way of formalizing what makes a good issue, and hopefully prevent future issue spam.

It's sparse since I'm not involved with this project and don't want to speak on its behalf, it's meant to be used as a jumping-off point. It just has very basic points, as a way of saying keep issues focused on the technical stuff.