### PR TITLE
Fix up build and improve readme file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,11 @@ mark_as_advanced(_CXX_FILESYSTEM_HAVE_HEADER)
 mark_as_advanced(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
 
 # Dependencies
-find_package(SDL2 REQUIRED)
-find_package(fmt REQUIRED)
-find_package(OpenAL REQUIRED) #find_package(openal-soft CONFIG REQUIRED)
-find_package(Bullet REQUIRED)
+find_package(SDL2 REQUIRED) # https://www.libsdl.org
+find_package(fmt REQUIRED) # https://fmt.dev
+find_package(OpenAL REQUIRED) #find_package(openal-soft CONFIG REQUIRED) # https://github.com/kcat/openal-soft
+find_package(Bullet REQUIRED) # http://www.bulletphysics.com/Bullet/
+find_package(glm REQUIRED) # http://glm.g-truc.net
 
 # Setup an interface library for Bullet, this allows us to target Debug/Release configurations properly.
 # This should be resolved once https://github.com/microsoft/vcpkg/pull/9098 is merged.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You still need to have the original game assets in order to use this.
     <img src="https://files.facepunch.com/Layla/2019/August/11/2019-08-09_22-11-26.png" width="45%">
 </a>
 
-# Building
+## Building
 
 Clone the code using: `git clone --recursive https://github.com/plowteam/donut.git`
 
@@ -32,7 +32,7 @@ Linux:~/$ ./vcpkg install sdl2 bullet3 openal-soft fmt
 If you don't want to use vcpkg; CMake will fallback on installed system dependencies, or manually specified
 package directories.
 
-## Windows
+### Windows
 
 * Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/)
 * Install [CMake](https://cmake.org/download/)
@@ -47,7 +47,7 @@ cd donut
 cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows
 ```
 
-## Linux
+### Linux
 
 *Note: These instructions are for Ubuntu, but can be easily applied to other distros.*
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ cmake --build build -j 5
 
 **Mesa drivers on Linux:** if you are trying to run with Mesa drivers and are getting issues with OpenGL context try messing with `MESA_GL_VERSION_OVERRIDE` when running like so: `MESA_GL_VERSION_OVERRIDE=4.3FC MESA_GLSL_VERSION_OVERRIDE=430 bin/donut`
 
+## Running
+
+The binary called `donut` should be launched from the root of the original game deployment (similar to original `Simpsons` binary). Additional assets from the `assets` source directory (both `windows` and `shaders`) should also be copied to the root of the original game deployment.
+
 ## Docs
 * [Chunks](dev/Chunks.md)
 * [Commands](dev/Commands.md)

--- a/src/Character.cpp
+++ b/src/Character.cpp
@@ -41,7 +41,7 @@ void Character::LoadModel(const std::string& name)
 		case P3D::ChunkType::Texture: Game::GetInstance().GetResourceManager().LoadTexture(*P3D::Texture::Load(*chunk)); break;
 		case P3D::ChunkType::PolySkin: _skinModel->LoadPolySkin(*P3D::PolySkin::Load(*chunk)); break;
 		case P3D::ChunkType::Skeleton: _skeleton = std::make_unique<Skeleton>(*P3D::Skeleton::Load(*chunk)); break;
-		default: fmt::print("unhandled chunk {1} in character {0}\n", name, chunk->GetType()); break;
+		default: fmt::print("unhandled chunk {1} in character {0}\n", name, fmt::underlying(chunk->GetType())); break;
 		}
 	}
 }

--- a/src/Core/MemoryStream.h
+++ b/src/Core/MemoryStream.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <cstring>
+#include <cstdint>
 
 namespace Donut
 {


### PR DESCRIPTION
- README: add section how to run the build
- README: clean up section levels
- cmake: improve dependencies list
- add missing header include (to use `uint8_t` from `cstdint`)
- fix build in formatting user-defined types

![image](https://github.com/plowteam/donut/assets/3686800/5a282c4e-2b49-4e96-81ed-7bf8824c5599)
